### PR TITLE
wscript: Fix duplicate manifest install

### DIFF
--- a/wscript
+++ b/wscript
@@ -103,14 +103,11 @@ def build(bld):
         tgt = task.outputs[0].abspath()
         return shutil.copy(src, tgt)
 
-    for i in bld.path.ant_glob('deteriorate.lv2/*.ttl'):
-        bld(features     = 'subst',
-            is_copy      = True,
-            source       = i,
-            target       = 'deteriorate.lv2/%s' % i.name,
-            install_path = '${LV2DIR}/deteriorate.lv2')
-
-
+    bld(features     = 'subst',
+        is_copy      = True,
+        source       = 'deteriorate.lv2/manifest.ttl',
+        target       = 'deteriorate.lv2/manifest.ttl',
+        install_path = '${LV2DIR}/deteriorate.lv2')
 
     plugins = '''
     downsampler_mono


### PR DESCRIPTION
The current wscript intermittently fails during install. After some digging it seems this is caused by the build script installing the same file multiple times:
```
./waf -vv --destdir="/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/" install
Waf: Entering directory `/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7/build'
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_mono.ttl (from build/deteriorate.lv2/downsampler_mono.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_stereo.ttl (from build/deteriorate.lv2/downsampler_stereo.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_mono.ttl (from build/deteriorate.lv2/granulator_mono.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_stereo.ttl (from build/deteriorate.lv2/granulator_stereo.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/manifest.ttl (from build/deteriorate.lv2/manifest.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_mono.so (from build/deteriorate.lv2/downsampler_mono.so)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_mono.ttl (from build/deteriorate.lv2/downsampler_mono.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_stereo.so (from build/deteriorate.lv2/downsampler_stereo.so)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_stereo.ttl (from build/deteriorate.lv2/downsampler_stereo.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_mono.ttl (from build/deteriorate.lv2/granulator_mono.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_mono.so (from build/deteriorate.lv2/granulator_mono.so)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_stereo.so (from build/deteriorate.lv2/granulator_stereo.so)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_stereo.ttl (from build/deteriorate.lv2/granulator_stereo.ttl)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_mono_gui.so (from build/deteriorate.lv2/downsampler_mono_gui.so)
- install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_stereo_gui.so (from build/deteriorate.lv2/downsampler_stereo_gui.so)
+ install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_mono_gui.so (from build/deteriorate.lv2/granulator_mono_gui.so)
+ install /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_stereo_gui.so (from build/deteriorate.lv2/granulator_stereo_gui.so)
* Node /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_mono.ttl is created more than once. The task generators are:
  1. bld(source=[], target='deteriorate.lv2/downsampler_mono.ttl', meths=['check_err_features', 'check_err_order', 'process_subst', 'process_rule', 'process_source'], features=['subst'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=1, tg_idx_count=1, is_copy=True, install_path='${LV2DIR}/deteriorate.lv2', posted=True, install_task=
	{task 140704488807440: inst downsampler_mono.ttl -> downsampler_mono.ttl}, _name='deteriorate.lv2/downsampler_mono.ttl') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
  2. bld(source=[], target='', meths=['check_err_features', 'check_err_order', 'process_install_task', 'process_rule', 'process_source'], features=['install_task'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=7, tg_idx_count=7, install_to='${LV2DIR}/deteriorate.lv2', install_from='deteriorate.lv2/downsampler_mono.ttl', dest='${LV2DIR}/deteriorate.lv2', type='install_files', posted=True, install_task=
	{task 140704488879264: inst downsampler_mono.ttl -> downsampler_mono.ttl}, _name='') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
If you think that this is an error, set no_errcheck_out on the task instance
* Node /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/downsampler_stereo.ttl is created more than once. The task generators are:
  1. bld(source=[], target='deteriorate.lv2/downsampler_stereo.ttl', meths=['check_err_features', 'check_err_order', 'process_subst', 'process_rule', 'process_source'], features=['subst'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=2, tg_idx_count=2, is_copy=True, install_path='${LV2DIR}/deteriorate.lv2', posted=True, install_task=
	{task 140704488807664: inst downsampler_stereo.ttl -> downsampler_stereo.ttl}, _name='deteriorate.lv2/downsampler_stereo.ttl') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
  2. bld(source=[], target='', meths=['check_err_features', 'check_err_order', 'process_install_task', 'process_rule', 'process_source'], features=['install_task'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=9, tg_idx_count=9, install_to='${LV2DIR}/deteriorate.lv2', install_from='deteriorate.lv2/downsampler_stereo.ttl', dest='${LV2DIR}/deteriorate.lv2', type='install_files', posted=True, install_task=
	{task 140704488879712: inst downsampler_stereo.ttl -> downsampler_stereo.ttl}, _name='') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
If you think that this is an error, set no_errcheck_out on the task instance
* Node /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_mono.ttl is created more than once. The task generators are:
  1. bld(source=[], target='deteriorate.lv2/granulator_mono.ttl', meths=['check_err_features', 'check_err_order', 'process_subst', 'process_rule', 'process_source'], features=['subst'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=3, tg_idx_count=3, is_copy=True, install_path='${LV2DIR}/deteriorate.lv2', posted=True, install_task=
	{task 140704488878368: inst granulator_mono.ttl -> granulator_mono.ttl}, _name='deteriorate.lv2/granulator_mono.ttl') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
  2. bld(source=[], target='', meths=['check_err_features', 'check_err_order', 'process_install_task', 'process_rule', 'process_source'], features=['install_task'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=11, tg_idx_count=11, install_to='${LV2DIR}/deteriorate.lv2', install_from='deteriorate.lv2/granulator_mono.ttl', dest='${LV2DIR}/deteriorate.lv2', type='install_files', posted=True, install_task=
	{task 140704488880272: inst granulator_mono.ttl -> granulator_mono.ttl}, _name='') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
If you think that this is an error, set no_errcheck_out on the task instance
* Node /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/image/usr/lib64/lv2/deteriorate.lv2/granulator_stereo.ttl is created more than once. The task generators are:
  1. bld(source=[], target='deteriorate.lv2/granulator_stereo.ttl', meths=['check_err_features', 'check_err_order', 'process_subst', 'process_rule', 'process_source'], features=['subst'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=4, tg_idx_count=4, is_copy=True, install_path='${LV2DIR}/deteriorate.lv2', posted=True, install_task=
	{task 140704488878592: inst granulator_stereo.ttl -> granulator_stereo.ttl}, _name='deteriorate.lv2/granulator_stereo.ttl') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
  2. bld(source=[], target='', meths=['check_err_features', 'check_err_order', 'process_install_task', 'process_rule', 'process_source'], features=['install_task'], path=/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7, idx=13, tg_idx_count=13, install_to='${LV2DIR}/deteriorate.lv2', install_from='deteriorate.lv2/granulator_stereo.ttl', dest='${LV2DIR}/deteriorate.lv2', type='install_files', posted=True, install_task=
	{task 140704488880832: inst granulator_stereo.ttl -> granulator_stereo.ttl}, _name='') in /var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7
If you think that this is an error, set no_errcheck_out on the task instance
Waf: Leaving directory `/var/tmp/portage/media-plugins/deteriorate-lv2-1.0.7-r1/work/deteriorate-lv2-1.0.7/build'
Build commands will be stored in build/compile_commands.json
'install' finished successfully (0.038s)
```

After checking the wscript indeed the manifest files are installed twice. Once as part of `subst` and the other as part of `install_files()` in `build_plugin`.
Since no actual substitution seems to be happening for them I've dropped the `subst` section in the wscript to fix this.